### PR TITLE
Add AppMenu component and refactor demo content headers

### DIFF
--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -9,7 +9,7 @@ import { captureResponsiveScreenshots, captureScreenshot } from './screenshot-ut
 test.describe('Responsive: Onboarding / Landing', () => {
   test('landing page renders at all viewports', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByText('Get Started')).toBeVisible();
+    await expect(page.getByTestId('landing-page')).toBeVisible();
     await captureResponsiveScreenshots(page, 'onboarding', 'getting-started');
   });
 
@@ -89,7 +89,7 @@ test.describe('Responsive: Settings Modal', () => {
     await page.keyboard.press('Escape');
 
     // Try clicking the settings button in sidebar if visible
-    const settingsBtn = page.locator('[data-testid="sidebar-settings"]');
+    const settingsBtn = page.locator('[data-testid="app-menu-settings"]');
     if (await settingsBtn.isVisible()) {
       await settingsBtn.click();
     }
@@ -192,7 +192,7 @@ test.describe('Responsive: Full-page Screenshots', () => {
   test('capture full documentation screenshots', async ({ page }) => {
     // Onboarding
     await page.goto('/');
-    await expect(page.getByText('Get Started')).toBeVisible();
+    await expect(page.getByTestId('landing-page')).toBeVisible();
     await captureScreenshot(page, {
       name: 'landing-desktop',
       category: 'overview',

--- a/e2e/tests/slash-commands.spec.ts
+++ b/e2e/tests/slash-commands.spec.ts
@@ -63,8 +63,8 @@ test.describe('Demo Mode', () => {
     await page.getByTestId('page-tree-button-features').click();
     await page.waitForTimeout(500);
 
-    // Check for various block types in the features page
-    await expect(page.locator('.cept-editor-content h1')).toContainText('Block Types');
+    // Check page header shows the features page title
+    await expect(page.getByTestId('page-title')).toContainText('Features');
     await captureScreenshot(page, { name: 'demo-features-top', category: 'demo' });
 
     // Scroll to see more blocks
@@ -82,7 +82,7 @@ test.describe('Demo Mode', () => {
     await openDemoEditor(page);
     await page.getByTestId('page-tree-button-getting-started').click();
     await page.waitForTimeout(500);
-    await expect(page.locator('.cept-editor-content h1')).toContainText('Getting Started');
+    await expect(page.getByTestId('page-title')).toContainText('Getting Started');
     await captureScreenshot(page, { name: 'demo-getting-started', category: 'demo' });
   });
 });

--- a/packages/ui/src/components/App.test.tsx
+++ b/packages/ui/src/components/App.test.tsx
@@ -182,7 +182,7 @@ describe('App', () => {
     // Page content should be in its own file
     const pageContent = await backend.readText(`pages/${pageId}.html`);
     expect(pageContent).not.toBeNull();
-    expect(pageContent).toContain('Welcome to Cept');
+    expect(pageContent).toContain('Start typing here');
   });
 
   it('restores state from backend on reload (individual page files)', async () => {
@@ -301,7 +301,7 @@ describe('App', () => {
     // Demo pages should have individual files
     const welcomeContent = await backend.readText('pages/welcome.html');
     expect(welcomeContent).not.toBeNull();
-    expect(welcomeContent).toContain('Welcome to Cept');
+    expect(welcomeContent).toContain('demo space');
   });
 
   it('demo mode shows demo content initially', async () => {

--- a/packages/ui/src/components/App.tsx
+++ b/packages/ui/src/components/App.tsx
@@ -24,6 +24,7 @@ import {
   deletePageContent,
 } from './storage/StorageContext.js';
 import { LandingPage } from './landing/LandingPage.js';
+import { AppMenu } from './app-menu/AppMenu.js';
 import { FolderView } from './editor/FolderView.js';
 import { ImportDialog } from './import-export/ImportDialog.js';
 import type { ImportSource } from './import-export/ImportDialog.js';
@@ -148,6 +149,7 @@ export function App() {
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
+
 
   // Deep linking: restore route from URL on load (handles 404 redirect + legacy hash)
   // Runs exactly once after initialization has populated pages.
@@ -430,7 +432,7 @@ export function App() {
       icon: '\u{1F44B}',
       children: [],
     };
-    const content = '<h1>Welcome to Cept</h1><p>Start typing here...</p>';
+    const content = '<p>Start typing here...</p>';
     setPages([firstPage]);
     setPageContents({ [firstPage.id]: content });
     setSelectedPageId(firstPage.id);
@@ -607,9 +609,11 @@ export function App() {
     { id: 'new-page', title: 'New Page', icon: '\u{1F4C4}', category: 'Pages', action: () => handlePageAdd() },
     { id: 'search', title: 'Search', icon: '\u{1F50D}', category: 'Navigation', action: () => { setCommandPaletteOpen(false); setSearchOpen(true); } },
     { id: 'toggle-sidebar', title: 'Toggle Sidebar', icon: '\u{1F4CB}', category: 'View', action: () => { setSidebarOpen((p) => !p); setCommandPaletteOpen(false); } },
+    { id: 'import-notion', title: 'Import from Notion', icon: '\u{1F4E5}', category: 'Import / Export', action: () => { setCommandPaletteOpen(false); handleOpenImport('notion'); } },
+    { id: 'import-obsidian', title: 'Import from Obsidian', icon: '\u{1F4E5}', category: 'Import / Export', action: () => { setCommandPaletteOpen(false); handleOpenImport('obsidian'); } },
     { id: 'export-page', title: 'Export Current Page', icon: '\u{1F4E4}', category: 'Import / Export', action: () => { setCommandPaletteOpen(false); handleOpenExport(); } },
     { id: 'manage-spaces', title: 'Manage Spaces', icon: '\u{1F4C2}', category: 'Spaces', action: () => { setCommandPaletteOpen(false); handleOpenSettings('spaces'); } },
-  ], [handlePageAdd, handleOpenExport, handleOpenSettings]);
+  ], [handlePageAdd, handleOpenExport, handleOpenSettings, handleOpenImport]);
 
   const currentContent = selectedPageId ? (pageContents[selectedPageId] ?? '') : '';
   const selectedNode = selectedPageId ? findNode(pages, selectedPageId) : undefined;
@@ -642,6 +646,10 @@ export function App() {
           <Breadcrumbs items={breadcrumbItems} onNavigate={handlePageSelect} />
         )}
         <div className="ml-auto" />
+        <AppMenu
+          onOpenSettings={handleOpenSettings}
+          onOpenDocs={handleOpenDocs}
+        />
       </header>
       <main className="flex flex-1 min-h-0">
         {sidebarOpen && (
@@ -895,7 +903,6 @@ function toggleNode(nodes: PageTreeNode[], id: string): PageTreeNode[] {
 
 
 const DEMO_CONTENT = `
-<h1>Welcome to Cept</h1>
 <p>This is a demo space running in your browser. All data is stored locally.</p>
 <div data-type="callout" data-icon="\uD83D\uDCA1" data-color="default"><p>Type <code>/</code> anywhere to see all available block types. Try it now!</p></div>
 <h2>Getting Started</h2>
@@ -914,7 +921,6 @@ const DEMO_CONTENT = `
 `;
 
 const DEMO_FEATURES_CONTENT = `
-<h1>Block Types</h1>
 <p>Cept supports a wide variety of content blocks. Type <code>/</code> in the editor to insert any of these.</p>
 
 <h2>Text Blocks</h2>
@@ -988,7 +994,6 @@ console.log(greet('world'));</code></pre>
 `;
 
 const DEMO_GETTING_STARTED_CONTENT = `
-<h1>Getting Started</h1>
 <p>Welcome to Cept! Here\u2019s how to get started with your space.</p>
 
 <h2>Creating Pages</h2>

--- a/packages/ui/src/components/sidebar/sidebar-styles.css
+++ b/packages/ui/src/components/sidebar/sidebar-styles.css
@@ -372,7 +372,6 @@
 .cept-sidebar-footer {
   flex-shrink: 0;
   padding: 0 0.5rem 0.5rem;
-  margin-top: auto;
 }
 
 .cept-sidebar-footer-divider {


### PR DESCRIPTION
## Summary
This PR introduces a new `AppMenu` component to the application header and refactors demo content by removing redundant page title headers. The changes improve the UI organization by centralizing settings and documentation access in a dedicated menu component.

## Key Changes
- **New AppMenu Component**: Added `AppMenu` component to the header that provides quick access to settings and documentation
- **Command Palette Integration**: Added import commands for Notion and Obsidian to the command palette
- **Demo Content Refactoring**: Removed `<h1>` title headers from demo page content (Welcome, Features, Getting Started) since page titles are now displayed separately via the page header
- **Initial Page Content**: Changed the default new page content from including "Welcome to Cept" heading to just "Start typing here..."
- **Sidebar Footer**: Removed `margin-top: auto` from sidebar footer CSS to adjust layout spacing
- **Test Updates**: Updated E2E tests to use more reliable selectors (`data-testid` attributes) instead of text content matching

## Implementation Details
- The `AppMenu` component is positioned in the header's right section (after breadcrumbs) and accepts `onOpenSettings` and `onOpenDocs` callbacks
- Import commands in the command palette now properly close the palette before triggering the import dialog
- Demo content strings were cleaned up to remove duplicate headers that are now handled by the page title display
- Test selectors were updated to target `landing-page`, `app-menu-settings`, and `page-title` test IDs for better test stability

https://claude.ai/code/session_01WumaRCr4Yg2Yj18nvG2j7P