### PR TITLE
Add icon reference documentation

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -25,6 +25,7 @@ Welcome to the Cept documentation. Cept is an open-source Notion alternative tha
 ## Reference
 
 - [Keyboard Shortcuts](reference/keyboard-shortcuts.md) — All keyboard shortcuts
+- [Icon Reference](reference/icon-reference.md) — Emoji icons used in the app
 - [Product Roadmap](reference/roadmap.md) — What's built and what's coming next
 
 ## Source

--- a/docs/content/reference/icon-reference.md
+++ b/docs/content/reference/icon-reference.md
@@ -1,0 +1,90 @@
+# Icon Reference
+
+Cept currently uses emoji characters as its icon set. A dedicated icon library with a proper open-source license is planned for the future.
+
+## Page Icons
+
+These emojis are used as default page and navigation icons throughout the app.
+
+| Icon | Emoji | Usage |
+|------|-------|-------|
+| 📄 | `📄` U+1F4C4 | Default page icon |
+| 📁 | `📁` U+1F4C1 | Folder / parent page (with children) |
+| 📂 | `📂` U+1F4C2 | Open folder / Manage Spaces command |
+| 📋 | `📋` U+1F4CB | Toggle Sidebar command / space icon |
+| 📝 | `📝` U+1F4DD | Notes / editable page |
+| 👋 | `👋` U+1F44B | Welcome page |
+| 🚀 | `🚀` U+1F680 | Getting Started |
+| ✨ | `��` U+2728 | Features |
+
+## Command Palette Icons
+
+These emojis appear in the command palette (Cmd/Ctrl + K).
+
+| Icon | Emoji | Usage |
+|------|-------|-------|
+| 📄 | `📄` U+1F4C4 | New Page |
+| 🔍 | `🔍` U+1F50D | Search |
+| 📋 | `📋` U+1F4CB | Toggle Sidebar |
+| 📥 | `📥` U+1F4E5 | Import (Notion / Obsidian) |
+| 📤 | `📤` U+1F4E4 | Export Current Page |
+| 📂 | `📂` U+1F4C2 | Manage Spaces |
+
+## Slash Command Icons
+
+These icons appear in the slash command menu (`/` in the editor).
+
+### Text
+
+| Icon | Symbol | Command |
+|------|--------|---------|
+| H1 | `H1` | Heading 1 |
+| H2 | `H2` | Heading 2 |
+| H3 | `H3` | Heading 3 |
+| </> | `</>` | Code Block |
+| \u201C | `\u201C` U+201C | Blockquote |
+| \u2014 | `\u2014` U+2014 | Divider |
+
+### Lists
+
+| Icon | Symbol | Command |
+|------|--------|---------|
+| \u2022 | `\u2022` U+2022 | Bullet List |
+| 1. | `1.` | Numbered List |
+| \u2611 | `\u2611` U+2611 | To-do / Checkbox |
+
+### Blocks
+
+| Icon | Emoji | Command |
+|------|-------|---------|
+| 💡 | `💡` U+1F4A1 | Callout |
+| ▶ | `▶` U+25B6 | Toggle (collapsible) |
+
+### Media
+
+| Icon | Emoji | Command |
+|------|-------|---------|
+| 🖼 | `🖼` U+1F5BC | Image |
+| 🎬 | `🎬` U+1F3AC | Embed (YouTube, Vimeo, etc.) |
+| 🔗 | `🔗` U+1F517 | Bookmark |
+
+### Tables
+
+| Icon | Emoji | Command |
+|------|-------|---------|
+| 🗂 | `🗂` U+1F5C2 | Table |
+
+### Layout
+
+| Icon | Symbol | Command |
+|------|--------|---------|
+| ‖ | `‖` U+2016 | 2 Columns |
+| ⦀ | `⦀` U+2980 | 3 Columns |
+
+### Advanced
+
+| Icon | Symbol | Command |
+|------|--------|---------|
+| 𝜋 | `𝜋` U+1D70B | Math Equation (LaTeX) |
+| 𝑥 | `𝑥` U+1D465 | Inline Math |
+| 📊 | `📊` U+1F4CA | Mermaid Diagram |


### PR DESCRIPTION
## Summary
Added comprehensive documentation for all emoji icons and symbols used throughout the Cept application, making it easier for users and contributors to understand the icon system.

## Changes
- Created new `docs/content/reference/icon-reference.md` with detailed tables documenting:
  - Page icons (default page, folders, welcome, getting started, etc.)
  - Command palette icons (new page, search, import/export, etc.)
  - Slash command icons organized by category (text formatting, lists, blocks, media, tables, layout, and advanced features)
  - Unicode code points for each icon for reference
- Updated `docs/content/index.md` to include a link to the new icon reference in the Reference section

## Details
The icon reference serves as a centralized guide for understanding the emoji and symbol choices used throughout the application. Each icon is documented with its Unicode code point, making it useful for both end users learning the UI and developers maintaining the codebase. The documentation notes that Cept currently uses emoji characters as a temporary solution, with plans to migrate to a dedicated icon library with proper open-source licensing in the future.

https://claude.ai/code/session_01Dw6Fi6JLngFjA3g5tQejDS