### PR TITLE
Remove branch filter from pull_request CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ['*']
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:


### PR DESCRIPTION
## Summary
Updated the CI workflow configuration to remove the branch filter restriction from pull request triggers, allowing CI to run on pull requests from all branches.

## Changes
- Removed `branches: [main]` filter from the `pull_request` trigger in the CI workflow
- The workflow will now execute on pull requests regardless of the target branch, while maintaining the existing event type filters (`opened`, `synchronize`, `reopened`, `ready_for_review`)

## Details
This change enables CI checks to run on pull requests targeting any branch, not just the main branch. This is useful for validating changes in feature branches and other development workflows where pull requests may target branches other than main.

https://claude.ai/code/session_012WqH1JCYbYX9Xs9jp2rBnh