### PR TITLE
Fix release workflow git configuration and upstream checks

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,25 +32,31 @@ jobs:
       - name: Run quality gate
         run: bun run validate
 
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Set up branch tracking so release-it doesn't fail on upstream check
+          git branch --set-upstream-to=origin/main main 2>/dev/null || true
+
       - name: Determine version bump
         id: version
         run: |
+          set +e
           # Get the recommended bump from conventional commits
-          NEXT_VERSION=$(bunx release-it --release-version --ci 2>/dev/null || echo "")
-          if [ -z "$NEXT_VERSION" ]; then
-            echo "No version bump detected from conventional commits"
+          NEXT_VERSION=$(bunx release-it --release-version --ci 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ] || [ -z "$NEXT_VERSION" ]; then
+            echo "No version bump detected from conventional commits (exit code: $EXIT_CODE)"
+            echo "Output: $NEXT_VERSION"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "Next version: $NEXT_VERSION"
           fi
-
-      - name: Configure git
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Release
         if: steps.version.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git branch --set-upstream-to=origin/main main 2>/dev/null || true
 
       - name: Release
         run: bun run release:ci -- --increment ${{ inputs.increment }} ${{ inputs.dry-run && '--dry-run' || '' }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,8 +7,8 @@
     "tagName": "v${version}",
     "push": true,
     "requireCleanWorkingDir": true,
-    "requireUpstream": true,
-    "getLatestTagFromAllRefs": false
+    "requireUpstream": false,
+    "getLatestTagFromAllRefs": true
   },
   "npm": {
     "publish": false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cept",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "description": "A fully-featured Notion clone backed by Git. Client-only. Offline-first. Collaborative.",


### PR DESCRIPTION
## Summary
This PR fixes issues with the automated release workflow by improving git configuration setup and adjusting release-it settings to handle CI environments more robustly.

## Key Changes
- **Git configuration timing**: Moved git user configuration earlier in the workflow (before version detection) so it's available for all subsequent git operations
- **Branch tracking setup**: Added `git branch --set-upstream-to=origin/main main` command in both auto-release and release workflows to ensure proper upstream tracking, preventing release-it from failing on upstream checks
- **Release-it configuration updates**:
  - Changed `requireUpstream` from `true` to `false` to allow releases in CI environments where upstream tracking may not be fully established
  - Changed `getLatestTagFromAllRefs` from `false` to `true` to properly detect tags from all refs in CI
- **Version detection robustness**: Improved error handling in the version bump detection step to capture and log both exit codes and output, making debugging easier when release-it fails
- **Version reset**: Updated package.json version from 0.1.0 to 0.0.1 (likely to align with actual release state)

## Implementation Details
The workflow now properly configures git before attempting any version detection, and the release-it configuration is more lenient with upstream requirements while being more thorough in tag detection. This combination should resolve CI-specific issues where git state isn't fully initialized before running release-it commands.

https://claude.ai/code/session_01RWAqFwsHjJ8qnR2WRs5eVM