### PR TITLE
fix: resolve CD pipeline failure and increase release verbosity

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,10 +18,18 @@ jobs:
     # Skip release commits to avoid infinite loops
     if: "!startsWith(github.event.head_commit.message, 'chore: release v')"
     steps:
+      - name: Authenticate as GitHub App
+        id: auth
+        uses: nsheaps/github-actions/.github/actions/github-app-auth@main
+        with:
+          app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
 
       - name: Install mise
         uses: jdx/mise-action@v2
@@ -34,17 +42,32 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           # Set up branch tracking so release-it doesn't fail on upstream check
           git branch --set-upstream-to=origin/main main 2>/dev/null || true
+
+      - name: Debug release-it state
+        run: |
+          echo "=== Git status ==="
+          git status
+          echo ""
+          echo "=== Current version ==="
+          node -p "require('./package.json').version"
+          echo ""
+          echo "=== Latest tags ==="
+          git tag --sort=-v:refname | head -10 || echo "No tags found"
+          echo ""
+          echo "=== Recent commits ==="
+          git log --oneline -10
+          echo ""
+          echo "=== release-it dry run ==="
+          bunx release-it --dry-run --verbose --ci 2>&1 || true
 
       - name: Determine version bump
         id: version
         run: |
           set +e
           # Get the recommended bump from conventional commits
-          NEXT_VERSION=$(bunx release-it --release-version --ci 2>&1)
+          NEXT_VERSION=$(bunx release-it --release-version --verbose --ci 2>&1)
           EXIT_CODE=$?
           set -e
 
@@ -60,6 +83,6 @@ jobs:
 
       - name: Release
         if: steps.version.outputs.skip != 'true'
-        run: bun run release:ci
+        run: bun run release:ci -- --verbose
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -19,7 +19,17 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Authenticate as GitHub App
+        id: auth
+        uses: nsheaps/github-actions/.github/actions/github-app-auth@main
+        with:
+          app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
 
       - uses: jdx/mise-action@v2
 
@@ -42,9 +52,6 @@ jobs:
 
       - name: Deploy to GitHub Pages (app/ subdirectory)
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
           # Fetch gh-pages branch or create it
           git fetch origin gh-pages || true
           git checkout gh-pages || git checkout --orphan gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Authenticate as GitHub App
+        id: auth
+        uses: nsheaps/github-actions/.github/actions/github-app-auth@main
+        with:
+          app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
 
       - name: Install mise
         uses: jdx/mise-action@v2
@@ -46,11 +54,20 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git branch --set-upstream-to=origin/main main 2>/dev/null || true
 
+      - name: Debug release-it state
+        run: |
+          echo "=== Current version ==="
+          node -p "require('./package.json').version"
+          echo ""
+          echo "=== Latest tags ==="
+          git tag --sort=-v:refname | head -10 || echo "No tags found"
+          echo ""
+          echo "=== Increment: ${{ inputs.increment }} ==="
+          echo "=== Dry run: ${{ inputs.dry-run }} ==="
+
       - name: Release
-        run: bun run release:ci -- --increment ${{ inputs.increment }} ${{ inputs.dry-run && '--dry-run' || '' }}
+        run: bun run release:ci -- --increment ${{ inputs.increment }} ${{ inputs.dry-run && '--dry-run' || '' }} --verbose
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -37,7 +37,7 @@
     },
     "@release-it/bumper": {
       "in": "package.json",
-      "out": ["package.json"]
+      "out": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause fix**: The auto-release workflow was failing with `npm error Version not changed` because `@release-it/bumper` plugin and release-it's built-in npm plugin were both writing to `package.json`, causing a double-bump conflict. Removed `package.json` from the bumper `out` array so only the npm plugin handles the version bump.
- **Increased verbosity**: Added `--verbose` flag to all `release-it` invocations and a new "Debug release-it state" step that logs current version, tags, recent commits, and a dry-run output before the actual release.
- **GitHub App authentication**: Switched all release workflows (`auto-release.yml`, `release.yml`, `release-web.yml`) from `secrets.GITHUB_TOKEN` to the org's GitHub App auth action (`nsheaps/github-actions/.github/actions/github-app-auth`), which provides proper permissions for pushing commits, tags, and creating GitHub releases. This mirrors the pattern used in `nsheaps/github-actions` CI workflows.

## Files Changed

| File | Change |
|---|---|
| `.release-it.json` | Emptied bumper `out` array to prevent double version bump |
| `.github/workflows/auto-release.yml` | Added GitHub App auth, debug step, verbose flags |
| `.github/workflows/release.yml` | Added GitHub App auth, debug step, verbose flags |
| `.github/workflows/release-web.yml` | Added GitHub App auth for gh-pages push |

## Root Cause Analysis

The CI logs showed:
```
- npm version
✖ npm version
ERROR npm error Version not changed
```

This is a [known issue](https://github.com/release-it/release-it/issues/779) when `@release-it/bumper` has `package.json` in its `out` array — the bumper plugin updates `package.json` first, then when the npm plugin tries `npm version`, it finds the version already matches and errors.

## Prerequisite

The `AUTOMATION_GITHUB_APP_ID` and `AUTOMATION_GITHUB_APP_PRIVATE_KEY` secrets must be available to this repository (either as repo secrets or inherited from the nsheaps organization). These are already used by `nsheaps/github-actions` and `nsheaps/.github` repos.

## Test Plan

- [ ] Verify `AUTOMATION_GITHUB_APP_ID` and `AUTOMATION_GITHUB_APP_PRIVATE_KEY` secrets are accessible from `nsheaps/cept`
- [ ] Merge to main and confirm auto-release workflow succeeds
- [ ] Verify the "Debug release-it state" step shows useful diagnostic info
- [ ] Confirm a GitHub release + tag is created automatically
- [ ] Verify release-web.yml can deploy to gh-pages on tag push

https://claude.ai/code/session_01CowQd6RG8QZSDocdtEJ2dK