### PR TITLE
fix: move checkout before github-app-auth in release workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,18 +18,18 @@ jobs:
     # Skip release commits to avoid infinite loops
     if: "!startsWith(github.event.head_commit.message, 'chore: release v')"
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Authenticate as GitHub App
         id: auth
         uses: nsheaps/github-actions/.github/actions/github-app-auth@main
         with:
           app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.auth.outputs.token }}
 
       - name: Install mise
         uses: jdx/mise-action@v2

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -19,17 +19,17 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Authenticate as GitHub App
         id: auth
         uses: nsheaps/github-actions/.github/actions/github-app-auth@main
         with:
           app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.auth.outputs.token }}
 
       - uses: jdx/mise-action@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Authenticate as GitHub App
         id: auth
         uses: nsheaps/github-actions/.github/actions/github-app-auth@main
         with:
           app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.auth.outputs.token }}
 
       - name: Install mise
         uses: jdx/mise-action@v2


### PR DESCRIPTION
## Summary

- Fixes the `fatal: not in a git directory` error causing all release workflows to fail
- The `github-app-auth` action runs `git config user.name` (local config) which requires being inside a git repository, but it was running **before** `actions/checkout`
- Moves `actions/checkout` before the auth step in all three affected workflows (`auto-release.yml`, `release.yml`, `release-web.yml`)
- Uses `persist-credentials: false` on checkout so the auth action can set up its own credentials

## Affected workflows

- `.github/workflows/auto-release.yml`
- `.github/workflows/release.yml`
- `.github/workflows/release-web.yml`

## Test plan

- [ ] Auto Release workflow passes on push to main
- [ ] Manual Release workflow runs successfully
- [ ] Release Web workflow runs successfully

https://claude.ai/code/session_012KqhD52DDkXcJmK94VpSVz