### PR TITLE
feat: link commit hash on about page to GitHub

### DIFF
--- a/packages/ui/src/components/settings/SettingsModal.tsx
+++ b/packages/ui/src/components/settings/SettingsModal.tsx
@@ -533,7 +533,7 @@ export function SettingsModal({
                 <p className="cept-settings-about-version" data-testid="about-version">
                   Version {typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0-dev'}
                   {typeof __COMMIT_SHA__ !== 'undefined' && __COMMIT_SHA__ && (
-                    <span className="cept-settings-about-commit"> ({__COMMIT_SHA__.slice(0, 7)})</span>
+                    <span className="cept-settings-about-commit"> (<a href={`https://github.com/nsheaps/cept/commit/${__COMMIT_SHA__}`} target="_blank" rel="noopener noreferrer">{__COMMIT_SHA__.slice(0, 7)}</a>)</span>
                   )}
                 </p>
                 <div className="cept-settings-section-divider" />


### PR DESCRIPTION
## Summary

- The short commit SHA displayed on the Settings > About page is now a clickable link that opens the corresponding commit on GitHub (`https://github.com/nsheaps/cept/commit/<sha>`)
- Link opens in a new tab with `rel="noopener noreferrer"` for security

## Test plan

- [x] Existing SettingsModal unit tests pass (17/17)
- [ ] Verify the link renders correctly when `__COMMIT_SHA__` is set (e.g., in a production build)
- [ ] Verify the link navigates to the correct GitHub commit page

https://claude.ai/code/session_01AGxrwUaQ915gGyiLcjBu8U