### PR TITLE
fix(ci): remove unnecessary build dependency on lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
     uses: ./.github/workflows/_test-e2e.yml
 
   build:
-    needs: [lint, test-unit]
     uses: ./.github/workflows/_build.yml
 
   screenshots:


### PR DESCRIPTION
## Summary

- Removes the `needs: [lint, test-unit]` dependency from the `build` job in the CI workflow
- The `build` job only verifies that the production build compiles — it has no logical dependency on lint or unit test results
- All six CI jobs (`lint`, `test-unit`, `test-integration`, `test-e2e`, `build`, `screenshots`) now run fully in parallel
- The `tag-release` job still gates on all jobs, so nothing ships unless everything passes

**Before:** `build` was sequentially blocked behind `lint` + `test-unit`, adding unnecessary wall-clock time to CI.

**After:** `build` runs immediately in parallel with all other jobs.

Note: E2E tests and screenshots don't need `build` because they use Playwright's `webServer` config to start a dev server (`bun run dev`) directly, not a production build.

## Test plan

- [ ] Verify CI workflow runs successfully with all jobs in parallel
- [ ] Verify `tag-release` still waits for all jobs before proceeding

https://claude.ai/code/session_01CuzCHKZ5tsNUYrmfGnFy8k