### PR TITLE
feat: isolate preview deployment storage

### DIFF
--- a/packages/web/src/deploy-namespace.test.ts
+++ b/packages/web/src/deploy-namespace.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { getDeploymentId, getDbName, namespacedKey, namespacedCache } from './deploy-namespace.js';
+
+describe('getDeploymentId', () => {
+  it('returns empty string for local dev (root path)', () => {
+    expect(getDeploymentId('/')).toBe('');
+  });
+
+  it('returns empty string for production deployment', () => {
+    expect(getDeploymentId('/cept/app/')).toBe('');
+  });
+
+  it('returns slug for PR preview deployment', () => {
+    expect(getDeploymentId('/cept/pr-42/')).toBe('cept-pr-42');
+  });
+
+  it('returns slug for different PR numbers', () => {
+    expect(getDeploymentId('/cept/pr-1/')).toBe('cept-pr-1');
+    expect(getDeploymentId('/cept/pr-999/')).toBe('cept-pr-999');
+  });
+
+  it('handles paths without trailing slash', () => {
+    expect(getDeploymentId('/cept/pr-5')).toBe('cept-pr-5');
+  });
+
+  it('handles arbitrary deployment paths', () => {
+    expect(getDeploymentId('/staging/')).toBe('staging');
+    expect(getDeploymentId('/cept/feature-branch/')).toBe('cept-feature-branch');
+  });
+});
+
+describe('getDbName', () => {
+  it('returns default name for production', () => {
+    expect(getDbName('/')).toBe('cept-workspace');
+    expect(getDbName('/cept/app/')).toBe('cept-workspace');
+  });
+
+  it('returns namespaced name for preview deployments', () => {
+    expect(getDbName('/cept/pr-42/')).toBe('cept-workspace--cept-pr-42');
+    expect(getDbName('/cept/pr-7/')).toBe('cept-workspace--cept-pr-7');
+  });
+});
+
+describe('namespacedKey', () => {
+  it('returns key unchanged for production', () => {
+    expect(namespacedKey('/', 'cept-sw-updated')).toBe('cept-sw-updated');
+    expect(namespacedKey('/cept/app/', 'cept-sw-updated')).toBe('cept-sw-updated');
+  });
+
+  it('prefixes key for preview deployments', () => {
+    expect(namespacedKey('/cept/pr-42/', 'cept-sw-updated')).toBe('cept-pr-42::cept-sw-updated');
+  });
+});
+
+describe('namespacedCache', () => {
+  it('returns cache name unchanged for production', () => {
+    expect(namespacedCache('/', 'cept-v1')).toBe('cept-v1');
+    expect(namespacedCache('/cept/app/', 'cept-static-v1')).toBe('cept-static-v1');
+  });
+
+  it('prefixes cache name for preview deployments', () => {
+    expect(namespacedCache('/cept/pr-42/', 'cept-v1')).toBe('cept-pr-42::cept-v1');
+    expect(namespacedCache('/cept/pr-42/', 'cept-static-v1')).toBe('cept-pr-42::cept-static-v1');
+  });
+});

--- a/packages/web/src/deploy-namespace.ts
+++ b/packages/web/src/deploy-namespace.ts
@@ -1,0 +1,51 @@
+/**
+ * Deployment namespace utilities.
+ *
+ * When multiple deployments share the same origin (e.g. GitHub Pages preview
+ * deployments at /cept/pr-N/), each needs isolated browser storage to prevent
+ * data from leaking between PRs and the production deployment.
+ *
+ * The namespace is derived from the deployment's base path (Vite BASE_URL).
+ */
+
+/**
+ * Derive a deployment ID slug from the base path.
+ *
+ * Returns an empty string for production and local dev (no isolation needed),
+ * and a slug like "cept-pr-123" for preview deployments.
+ *
+ * Examples:
+ *   "/"            → ""           (local dev)
+ *   "/cept/app/"   → ""           (production)
+ *   "/cept/pr-42/" → "cept-pr-42" (preview)
+ */
+export function getDeploymentId(basePath: string): string {
+  const slug = basePath.replace(/^\/+|\/+$/g, '').replace(/\//g, '-');
+  // Production and local dev use default namespace (backwards compatible)
+  if (!slug || slug === 'cept-app') return '';
+  return slug;
+}
+
+/** Get the IndexedDB database name for this deployment. */
+export function getDbName(basePath: string): string {
+  const id = getDeploymentId(basePath);
+  return id ? `cept-workspace--${id}` : 'cept-workspace';
+}
+
+/**
+ * Prefix a storage key (localStorage/sessionStorage) with the deployment namespace.
+ * Returns the key unchanged for production/local dev.
+ */
+export function namespacedKey(basePath: string, key: string): string {
+  const id = getDeploymentId(basePath);
+  return id ? `${id}::${key}` : key;
+}
+
+/**
+ * Prefix a cache name with the deployment namespace.
+ * Returns the name unchanged for production/local dev.
+ */
+export function namespacedCache(basePath: string, cacheName: string): string {
+  const id = getDeploymentId(basePath);
+  return id ? `${id}::${cacheName}` : cacheName;
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -5,8 +5,9 @@ import { BrowserFsBackend } from '@cept/core';
 import '@cept/ui/styles/globals.css';
 import { registerServiceWorker, consumeUpdateFlag } from './sw-register.js';
 import { UpdateToast } from './UpdateToast.js';
+import { getDbName } from './deploy-namespace.js';
 
-const backend = new BrowserFsBackend('cept-workspace');
+const backend = new BrowserFsBackend(getDbName(import.meta.env.BASE_URL));
 
 // Initialize the workspace structure (creates dirs if needed, no-ops if they exist)
 void backend.initialize({ name: 'My Space' });

--- a/packages/web/src/service-worker.ts
+++ b/packages/web/src/service-worker.ts
@@ -21,9 +21,30 @@ interface SWGlobalScope {
 
 declare const self: SWGlobalScope;
 
-const CACHE_NAME = 'cept-v1';
-const STATIC_CACHE = 'cept-static-v1';
-const DATA_CACHE = 'cept-data-v1';
+/**
+ * Derive a deployment ID from the service worker's URL path so that preview
+ * deployments on the same origin get isolated caches.
+ *
+ * Examples:
+ *   /service-worker.js            → "" (local dev)
+ *   /cept/app/service-worker.js   → "" (production)
+ *   /cept/pr-42/service-worker.js → "cept-pr-42"
+ */
+function getDeploymentId(): string {
+  const swPath = self.location.pathname;
+  // Strip the filename to get the base path, then slugify
+  const base = swPath.replace(/\/[^/]*$/, '');
+  const slug = base.replace(/^\/+|\/+$/g, '').replace(/\//g, '-');
+  if (!slug || slug === 'cept-app') return '';
+  return slug;
+}
+
+const DEPLOY_ID = getDeploymentId();
+const CACHE_PREFIX = DEPLOY_ID ? `${DEPLOY_ID}::` : '';
+
+const CACHE_NAME = `${CACHE_PREFIX}cept-v1`;
+const STATIC_CACHE = `${CACHE_PREFIX}cept-static-v1`;
+const DATA_CACHE = `${CACHE_PREFIX}cept-data-v1`;
 
 /** Static assets to precache on install */
 const PRECACHE_URLS = [

--- a/packages/web/src/sw-register.ts
+++ b/packages/web/src/sw-register.ts
@@ -5,8 +5,10 @@
  * user always sees the latest content.
  */
 
+import { namespacedKey } from './deploy-namespace.js';
+
 /** Key used in sessionStorage to signal a post-update reload */
-export const UPDATE_FLAG_KEY = 'cept-sw-updated';
+export const UPDATE_FLAG_KEY = namespacedKey(import.meta.env.BASE_URL, 'cept-sw-updated');
 
 export interface SWRegistrationCallbacks {
   /** Called when a new service worker is waiting to activate */


### PR DESCRIPTION
## Summary

- Derives a deployment namespace from the Vite `BASE_URL` so that each preview deployment at `/cept/pr-N/` gets completely isolated browser storage (IndexedDB, service worker caches, sessionStorage)
- Production (`/cept/app/`) and local dev (`/`) remain backwards-compatible with existing storage names
- Adds `deploy-namespace.ts` utility module with full test coverage (12 tests)

### Storage isolation details

| Storage layer | Production | PR Preview (e.g. PR #42) |
|---|---|---|
| IndexedDB database | `cept-workspace` | `cept-workspace--cept-pr-42` |
| SW cache names | `cept-v1`, `cept-static-v1`, `cept-data-v1` | `cept-pr-42::cept-v1`, etc. |
| sessionStorage key | `cept-sw-updated` | `cept-pr-42::cept-sw-updated` |

This ensures that testing multiple PRs simultaneously on the same GitHub Pages origin won't have data from one PR pollute or invalidate testing of another.

## Test plan

- [x] All 1614 existing unit tests pass (including service worker cache name assertions)
- [x] 12 new tests for `deploy-namespace.ts` covering all namespace functions
- [x] TypeScript typecheck passes (no new errors)
- [x] ESLint passes on all changed files
- [ ] Deploy a preview for this PR and verify IndexedDB name includes `pr-N` in DevTools > Application > IndexedDB
- [ ] Open two preview deployments (different PRs) side-by-side and verify they have independent data
- [ ] Verify production deployment at `/cept/app/` still uses `cept-workspace` (no regression)

https://claude.ai/code/session_01DfsZrrDobsyKVoypN3adx9