### PR TITLE
Improve table header cell visibility in dark mode editor

### DIFF
--- a/packages/ui/src/components/editor/editor-styles.css
+++ b/packages/ui/src/components/editor/editor-styles.css
@@ -959,8 +959,8 @@
   .cept-block-action-item:hover { background-color: #333; }
   .cept-block-action-divider { background-color: #404040; }
   .cept-editor .tiptap table.cept-table td.cept-table-cell,
-  .cept-editor .tiptap table.cept-table th.cept-table-header-cell { border-color: #404040; }
-  .cept-editor .tiptap table.cept-table th.cept-table-header-cell { background-color: #1e1e1e; }
+  .cept-editor .tiptap table.cept-table th.cept-table-header-cell { border-color: #404040; color: #d4d4d8; }
+  .cept-editor .tiptap table.cept-table th.cept-table-header-cell { background-color: #1e1e1e; color: #e5e5e5; }
   .cept-editor .tiptap table.cept-table .selectedCell::after { background: rgba(99, 102, 241, 0.2); }
   .cept-folder-view-item { color: #d4d4d8; }
   .cept-folder-view-item:hover { background-color: #333; }


### PR DESCRIPTION
## Summary
Enhanced the visual appearance of table header cells in the dark mode editor by adding explicit text color styling to improve readability and contrast.

## Changes
- Added text color (`#d4d4d8`) to table header cell borders styling
- Added text color (`#e5e5e5`) to table header cell background styling for better contrast against the dark background (`#1e1e1e`)

## Details
The table header cells in the editor's dark theme were missing explicit text color definitions, which could result in poor readability. This change ensures that header cell text is clearly visible with appropriate contrast ratios against the dark background, improving the overall user experience when working with tables in the editor.

https://claude.ai/code/session_01NmQapiNyKL7UZHZX7ghpBU