### PR TITLE
feat: full-page settings modal on mobile

### DIFF
--- a/packages/ui/src/components/settings/settings-styles.css
+++ b/packages/ui/src/components/settings/settings-styles.css
@@ -423,8 +423,20 @@
   color: #9ca3af;
 }
 
-/* Mobile: stack tabs horizontally */
-@media (max-width: 480px) {
+/* Mobile: full-page settings */
+@media (max-width: 640px) {
+  .cept-settings-overlay {
+    align-items: stretch;
+    justify-content: stretch;
+  }
+  .cept-settings-dialog {
+    width: 100%;
+    max-width: none;
+    max-height: none;
+    height: 100dvh;
+    border-radius: 0;
+    box-shadow: none;
+  }
   .cept-settings-body {
     flex-direction: column;
   }
@@ -438,6 +450,14 @@
   .cept-settings-tab {
     white-space: nowrap;
     flex-shrink: 0;
+  }
+  .cept-wizard-dialog {
+    width: 100%;
+    max-width: none;
+    max-height: none;
+    height: 100dvh;
+    border-radius: 0;
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
## Summary

- Settings modal now renders as a full-page view on mobile viewports (≤640px), matching the `useResponsive` hook's mobile breakpoint
- Add-space wizard modal also goes full-page on mobile
- Dialog fills 100dvh with no border-radius or box-shadow for a native app feel
- Horizontal tab bar with scroll is preserved for navigation

## Test plan

- [ ] Open settings modal on desktop — should appear as centered dialog (unchanged)
- [ ] Open settings modal on mobile viewport (≤640px) — should fill the entire screen
- [ ] Verify all tabs (Settings, Spaces, Data & Cache, About) work in full-page mode
- [ ] Verify Add Space wizard also goes full-page on mobile
- [ ] Check dark mode styling in both desktop and mobile views
- [ ] All 1654 existing tests pass

https://claude.ai/code/session_01EizVdF7zSeP1rHR3qpPfkW