### PR TITLE
feat: close modals by clicking the backdrop veil

### DIFF
--- a/packages/ui/src/components/import-export/ExportDialog.test.tsx
+++ b/packages/ui/src/components/import-export/ExportDialog.test.tsx
@@ -106,4 +106,13 @@ describe('ExportDialog', () => {
     screen.getByTestId('export-close').click();
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('calls onClose on overlay click', () => {
+    const onClose = vi.fn();
+    render(
+      <ExportDialog isOpen={true} onClose={onClose} page={testPage} />,
+    );
+    fireEvent.click(screen.getByTestId('export-dialog'));
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/packages/ui/src/components/import-export/ExportDialog.tsx
+++ b/packages/ui/src/components/import-export/ExportDialog.tsx
@@ -44,8 +44,8 @@ export function ExportDialog({ isOpen, onClose, page }: ExportDialogProps) {
   if (!isOpen || !page) return null;
 
   return (
-    <div className="cept-modal-overlay" data-testid="export-dialog">
-      <div className="cept-modal-content" style={{ maxWidth: 400 }}>
+    <div className="cept-modal-overlay" onClick={onClose} data-testid="export-dialog">
+      <div className="cept-modal-content" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 400 }}>
         <div className="cept-modal-header">
           <h2>Export Page</h2>
           <button

--- a/packages/ui/src/components/import-export/ImportDialog.test.tsx
+++ b/packages/ui/src/components/import-export/ImportDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ImportDialog } from './ImportDialog.js';
 
 describe('ImportDialog', () => {
@@ -64,6 +64,20 @@ describe('ImportDialog', () => {
       />,
     );
     screen.getByTestId('import-close').click();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose on overlay click', () => {
+    const onClose = vi.fn();
+    render(
+      <ImportDialog
+        isOpen={true}
+        source="notion"
+        onClose={onClose}
+        onImportComplete={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('import-dialog'));
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/import-export/ImportDialog.tsx
+++ b/packages/ui/src/components/import-export/ImportDialog.tsx
@@ -153,8 +153,8 @@ export function ImportDialog({ isOpen, source, onClose, onImportComplete }: Impo
   const accept = source === 'notion' ? '.zip' : undefined;
 
   return (
-    <div className="cept-modal-overlay" data-testid="import-dialog">
-      <div className="cept-modal-content" style={{ maxWidth: 500 }}>
+    <div className="cept-modal-overlay" onClick={onClose} data-testid="import-dialog">
+      <div className="cept-modal-content" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 500 }}>
         <div className="cept-modal-header">
           <h2>{title}</h2>
           <button

--- a/packages/ui/src/components/settings/AddSpaceWizardModal.test.tsx
+++ b/packages/ui/src/components/settings/AddSpaceWizardModal.test.tsx
@@ -178,4 +178,11 @@ describe('AddSpaceWizardModal', () => {
     act(() => { fireEvent.click(screen.getByTestId('wizard-choose-git')); });
     expect((screen.getByTestId('wizard-remote-url-input') as HTMLInputElement).value).toBe('github.com/nsheaps/cept');
   });
+
+  it('calls onClose on overlay click', () => {
+    const onClose = vi.fn();
+    render(<AddSpaceWizardModal {...defaultProps} onClose={onClose} />);
+    act(() => { fireEvent.click(screen.getByTestId('add-space-wizard-modal')); });
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/packages/ui/src/components/settings/AddSpaceWizardModal.tsx
+++ b/packages/ui/src/components/settings/AddSpaceWizardModal.tsx
@@ -66,8 +66,8 @@ export function AddSpaceWizardModal({
   if (!isOpen) return null;
 
   return (
-    <div className="cept-wizard-overlay" data-testid="add-space-wizard-modal">
-      <div className="cept-wizard-dialog">
+    <div className="cept-wizard-overlay" onClick={resetAndClose} data-testid="add-space-wizard-modal">
+      <div className="cept-wizard-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="cept-wizard-header">
           {step !== 'choose-type' && (
             <button

--- a/packages/ui/src/components/settings/SettingsModal.test.tsx
+++ b/packages/ui/src/components/settings/SettingsModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { SettingsModal, DEFAULT_SETTINGS } from './SettingsModal.js';
 import type { SpaceInfo } from './SettingsModal.js';
 
@@ -192,5 +192,12 @@ describe('SettingsModal', () => {
     render(<SettingsModal {...defaultProps} onResetSettings={onResetSettings} />);
     screen.getByTestId('reset-settings-btn').click();
     expect(onResetSettings).toHaveBeenCalled();
+  });
+
+  it('calls onClose on overlay click', () => {
+    const onClose = vi.fn();
+    render(<SettingsModal {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByTestId('settings-modal'));
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/settings/SettingsModal.tsx
+++ b/packages/ui/src/components/settings/SettingsModal.tsx
@@ -161,8 +161,8 @@ export function SettingsModal({
     : null;
 
   return (
-    <div className="cept-settings-overlay" data-testid="settings-modal">
-      <div className="cept-settings-dialog">
+    <div className="cept-settings-overlay" onClick={onClose} data-testid="settings-modal">
+      <div className="cept-settings-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="cept-settings-header">
           <h2>Settings</h2>
           {savedIndicator && (


### PR DESCRIPTION
## Summary

- Clicking the semi-transparent backdrop (veil) behind modal dialogs now closes them, matching the existing behavior of CommandPalette and SearchPanel
- Uses `stopPropagation()` on dialog content to prevent clicks inside the modal from triggering close
- Applies to: **SettingsModal**, **AddSpaceWizardModal**, **ExportDialog**, **ImportDialog**
- Intentionally excludes the **clone status dialog** (no X button, required workflow step)

## Test plan

- [x] Added overlay click tests for all 4 affected modals
- [x] All 1696 unit tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: open Settings modal, click backdrop → modal closes
- [ ] Manual: open Add Space wizard, click backdrop → wizard closes and resets
- [ ] Manual: open Export dialog, click backdrop → dialog closes
- [ ] Manual: open Import dialog, click backdrop → dialog closes
- [ ] Manual: clone a repo → clone status overlay does NOT close on backdrop click

https://claude.ai/code/session_01E9jYjkHtYE6D1Xp5JGSyEU